### PR TITLE
Improved warning UX for bad asset cases + generated icon

### DIFF
--- a/Editor/SmartTextureImporter.cs
+++ b/Editor/SmartTextureImporter.cs
@@ -114,10 +114,8 @@ public class SmartTextureImporter : ScriptedImporter
 
             ApplyPropertiesViaSerializedObj(texture);
         }
-        
-		//If we pass the tex to the 3rd arg we can have it show in an Icon as normal, maybe configurable?
-        //ctx.AddObjectToAsset("mask", texture, texture);
-		ctx.AddObjectToAsset("mask", texture);
+
+        ctx.AddObjectToAsset("mask", texture, texture);
         ctx.SetMainObject(texture);
     }
 


### PR DESCRIPTION
This PR is taking some design liberty on the UX. 

Importantly I also now allow a smart texture to be created from images that do not match in size. This does create some artefacts as shown below but the case is warned to the end-user so they can investigate and decide what to do. In future, these inputs could maybe be resized on the CPU with a nicer algo to mitigate this issue.

_Original_
![image](https://user-images.githubusercontent.com/8888300/82589215-b78a1880-9b93-11ea-85ff-44ab67a76210.png)
_Output_
![image](https://user-images.githubusercontent.com/8888300/82589196-af31dd80-9b93-11ea-9d26-f548601db6c2.png)

- I have implemented warnings for the following cases, clicking these warnings navigates to the asset
-- Size mismatch
-- Compressed input texture (The way I detect whether a format is compressed could be improved but there isn't a simple built-in check to find this out)
- Generated icon
-- In order to match basic texture UX the smart textures icon is now a small version of the output texture.